### PR TITLE
[ADD] real_state_management: data demo contable (asiento descuadrado)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Un cliente de Adhoc tiene instalado el módulo real_state_management y notifican
     Recibe como parámetro el identificador de la propiedad y los datos necesarios para completar la oferta.
     Debe devolver el mensaje: "Oferta creada" si la operación fue exitosa.
 
+7. Revisión contable de la data.
+  El módulo carga (como data demo) algunos asientos contables de ejemplo en Contabilidad > Asientos contables.
+  Se pide revisar esa información con criterio contable, detectar cualquier inconsistencia y plantearla:
+  ¿los asientos son correctos? ¿alguno no cierra? ¿qué preguntarías o cómo lo corregirías?
+
 
 ## Ejercicio:
 

--- a/real_state_management/__manifest__.py
+++ b/real_state_management/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "Real State Management",
     "version": "18.0.1.0.0",
-    "depends": ["base"],
+    "depends": ["base", "account"],
     "license": "LGPL-3",
     "data": [
         "data/estate.property.type.csv",
@@ -13,6 +13,9 @@
         "views/estate_property_tag_views.xml",
         "views/estate_property_offer_views.xml",
         "views/estate_menus.xml",
+    ],
+    "demo": [
+        "demo/account_demo.xml",
     ],
     "installable": True,
     "auto_install": False,

--- a/real_state_management/demo/account_demo.xml
+++ b/real_state_management/demo/account_demo.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+
+    <!--
+        Data demo contable para la actividad.
+
+        Dispara la generacion de asientos de ejemplo. Uno de ellos queda
+        deliberadamente descuadrado (debe != haber) para que quien resuelve la
+        actividad detecte la inconsistencia contable.
+
+        Ver: models/account_move.py -> _generate_estate_accounting_demo
+    -->
+    <function model="account.move" name="_generate_estate_accounting_demo"/>
+
+</odoo>

--- a/real_state_management/models/__init__.py
+++ b/real_state_management/models/__init__.py
@@ -2,3 +2,4 @@ from . import estate_property
 from . import estate_property_type
 from . import estate_property_tag
 from . import estate_property_offer
+from . import account_move

--- a/real_state_management/models/account_move.py
+++ b/real_state_management/models/account_move.py
@@ -1,0 +1,131 @@
+import logging
+
+from odoo import Command, api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.model
+    def _generate_estate_accounting_demo(self):
+        """Genera asientos contables de ejemplo para la actividad de reclutamiento.
+
+        Crea dos asientos:
+          1. Uno correcto (debe == haber), a modo de contraste.
+          2. Uno DELIBERADAMENTE descuadrado. Se arma balanceado con el ORM
+             (para pasar la validacion ``_check_balanced``) y luego se rompe el
+             balance con un ``UPDATE`` SQL directo, salteando esa validacion.
+
+        La intencion es que quien resuelve la actividad demuestre criterio
+        contable: al mirar la data tiene que darse cuenta de que ese asiento no
+        cuadra (debe != haber) y plantearlo.
+
+        Nota: el asiento descuadrado queda en un estado "sucio". Se ve bien en
+        la vista, pero cualquier edicion/guardado vuelve a disparar
+        ``_check_balanced`` y ahi si Odoo bloquea. Es esperado.
+        """
+        company = self.env.company
+        Journal = self.env["account.journal"]
+        Account = self.env["account.account"]
+
+        journal = Journal.search(
+            [*Journal._check_company_domain(company.id), ("type", "=", "general")],
+            limit=1,
+        )
+        accounts = Account.search(
+            [*Account._check_company_domain(company.id)],
+            limit=2,
+        )
+        if not journal or len(accounts) < 2:
+            _logger.warning(
+                "real_state_management: no hay diario 'general' o plan de cuentas "
+                "disponible; se omite la data demo contable."
+            )
+            return
+
+        account_a, account_b = accounts[0], accounts[1]
+        today = fields.Date.context_today(self)
+
+        # 1) Asiento correcto: debe == haber (1000 == 1000).
+        self.create(
+            {
+                "move_type": "entry",
+                "journal_id": journal.id,
+                "date": today,
+                "ref": "Actividad - Asiento correcto",
+                "line_ids": [
+                    Command.create(
+                        {
+                            "account_id": account_a.id,
+                            "name": "Debe",
+                            "debit": 1000.0,
+                            "credit": 0.0,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "account_id": account_b.id,
+                            "name": "Haber",
+                            "debit": 0.0,
+                            "credit": 1000.0,
+                        }
+                    ),
+                ],
+            }
+        )
+
+        # 2) Asiento a revisar: se crea balanceado (1500 == 1500) para pasar la
+        #    validacion del ORM y luego se descuadra por SQL.
+        unbalanced = self.create(
+            {
+                "move_type": "entry",
+                "journal_id": journal.id,
+                "date": today,
+                "ref": "Actividad - Revisar este asiento",
+                "line_ids": [
+                    Command.create(
+                        {
+                            "account_id": account_a.id,
+                            "name": "Debe",
+                            "debit": 1500.0,
+                            "credit": 0.0,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "account_id": account_b.id,
+                            "name": "Haber",
+                            "debit": 0.0,
+                            "credit": 1500.0,
+                        }
+                    ),
+                ],
+            }
+        )
+
+        # Nos aseguramos de que las lineas esten persistidas antes del UPDATE crudo.
+        self.env.flush_all()
+        debit_line = unbalanced.line_ids.filtered(lambda line: line.debit)[:1]
+
+        # Rompemos el balance: el debe pasa de 1500 a 1800 sin tocar el haber
+        # (1500). Queda un descuadre de 300 que el ORM no dejaria guardar por
+        # _check_balanced, pero que via SQL directo si persiste.
+        self.env.cr.execute(
+            """
+            UPDATE account_move_line
+               SET debit = debit + 300,
+                   balance = balance + 300,
+                   amount_currency = amount_currency + 300
+             WHERE id = %s
+            """,
+            [debit_line.id],
+        )
+
+        # Invalidamos la cache para que el descuadre se refleje al leer el asiento.
+        self.env.invalidate_all()
+        _logger.info(
+            "real_state_management: data demo contable creada (asiento %s descuadrado).",
+            unbalanced.id,
+        )


### PR DESCRIPTION
## Qué

Agrega **data demo contable** al módulo `real_state_management` para que la actividad de reclutamiento evalúe el criterio contable del candidato.

Se cargan dos asientos (`account.move`):

1. **Correcto** — debe == haber (1000 / 1000), a modo de contraste.
2. **Descuadrado** — debe 1800 vs haber 1500. Se arma balanceado con el ORM (para pasar `_check_balanced`) y luego se rompe el balance con un `UPDATE` SQL directo, salteando esa validación. La idea es que el candidato lo detecte al mirar la data y lo plantee.

## Cambios

- `__manifest__.py`: dependencia `account` + sección `demo` con `demo/account_demo.xml`.
- `models/account_move.py` (nuevo): herencia de `account.move` con `_generate_estate_accounting_demo()`. Guard defensivo si no hay diario/plan de cuentas.
- `demo/account_demo.xml` (nuevo): `<function>` que dispara la generación.
- `README.md`: punto 7 de consigna — revisar la data contable, detectar inconsistencias y plantearlas.

## Notas

- El módulo apunta a **Odoo 18**. La lógica del descuadre se validó en aislamiento contra el módulo `account` (API idéntica en 18/19): el asiento persiste con `sum(balance) = 300` y releerlo no re-dispara la validación.
- El asiento descuadrado queda en estado "sucio": se ve bien en la vista, pero si se **edita y guarda**, Odoo vuelve a correr `_check_balanced` y bloquea. Es el comportamiento esperado para el objetivo de la actividad.